### PR TITLE
ISO message header support

### DIFF
--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ConnectionRequestHandler.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ConnectionRequestHandler.java
@@ -66,14 +66,14 @@ public class ConnectionRequestHandler implements Runnable {
     public void connect() throws IOException {
         if (connection.isConnected()) {
             try {
-                String fromClient = "";
+                String fromClient;
                 /*
                 jpos sever supports the ISO message with the HeaderLength 0,2 and 4.
                 If the headerLength is 2 or 4, get the ISO message Length from the header value
                 and then read ISO message as byte using that messageLength.
                 Otherwise(headerLength=0) read the ISO message as String.
                  */
-                if (headerLength == 2 || headerLength == 4) {
+                if (headerLength != 0) {
                     int messageLength = getMessageLength(headerLength);
                     byte[] message = new byte[messageLength];
                     getMessage(message, 0, messageLength);
@@ -97,6 +97,10 @@ public class ConnectionRequestHandler implements Runnable {
     protected int getMessageLength(int headerLength) throws IOException, ISOException {
         if (headerLength == 4) {
             header = new byte[4];
+            /*
+             The size of the message will be sent by the client using the first 4 bytes of the header.
+              Get that header and decoding it and getting the message size
+             */
             inputStreamReader.readFully(header, 0, 4);
             return (header[0] & 0xFF) << 24 | (header[1] & 0xFF) << 16 | (header[2] & 0xFF) << 8 | header[3] & 0xFF;
         } else {

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ConnectionRequestHandler.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ConnectionRequestHandler.java
@@ -48,7 +48,7 @@ public class ConnectionRequestHandler implements Runnable {
         try {
             this.connection = connection;
             Properties properties = params.getProperties();
-            if (!StringUtils.isEmpty(properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH))) {
+            if (StringUtils.isNotEmpty(properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH))) {
                 this.headerLength = Integer.parseInt(properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH));
             }
             this.packager = ISO8583PackagerFactory.getPackager();
@@ -90,10 +90,25 @@ public class ConnectionRequestHandler implements Runnable {
         }
     }
 
-    protected void getMessage(byte[] message, int offset, int len) throws IOException, ISOException {
-        inputStreamReader.readFully(message, offset, len);
+    /**
+     * Get the ISO message from the input steam reader
+     * @param message the buffer into which the message is read
+     * @param offset the start offset of the message.
+     * @param length the length of the message
+     * @throws IOException
+     * @throws ISOException
+     */
+    protected void getMessage(byte[] message, int offset, int length) throws IOException, ISOException {
+        inputStreamReader.readFully(message, offset, length);
     }
 
+    /**
+     * Get the message length
+     * @param headerLength the length oh the header
+     * @return
+     * @throws IOException
+     * @throws ISOException
+     */
     protected int getMessageLength(int headerLength) throws IOException, ISOException {
         if (headerLength == 4) {
             header = new byte[4];

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ConnectionRequestHandler.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ConnectionRequestHandler.java
@@ -20,6 +20,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
 import org.apache.synapse.inbound.InboundProcessorParams;
+import org.jpos.iso.ISOBasePackager;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOMsg;
 import org.jpos.iso.ISOPackager;
@@ -28,6 +29,7 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.net.Socket;
+import java.util.Properties;
 
 /**
  * Class for handling the iso message request.
@@ -35,7 +37,7 @@ import java.net.Socket;
 public class ConnectionRequestHandler implements Runnable {
     private static final Log log = LogFactory.getLog(ConnectionRequestHandler.class);
     private Socket connection;
-    private ISOPackager packager;
+    private ISOBasePackager packager;
     private ISO8583MessageInject msgInject;
     private DataInputStream inputStreamReader;
     private DataOutputStream outToClient;
@@ -43,7 +45,7 @@ public class ConnectionRequestHandler implements Runnable {
     public ConnectionRequestHandler(Socket connection, InboundProcessorParams params) {
         try {
             this.connection = connection;
-            this.packager = ISO8583PackagerFactory.getPackager();
+            this.packager = ISO8583PackagerFactory.getPackagerWithParams(params);
             this.msgInject = new ISO8583MessageInject(params, connection);
             this.inputStreamReader = new DataInputStream(connection.getInputStream());
             this.outToClient = new DataOutputStream(connection.getOutputStream());

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583Constant.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583Constant.java
@@ -19,11 +19,11 @@ package org.wso2.carbon.inbound.iso8583.listening;
  * Class ISO8583Constant defines all constants used for ISO8583 inbound.
  */
 public class ISO8583Constant {
+    public final static String HEADER = "header";
     public final static String TAG_FIELD = "field";
     public final static String TAG_MSG = "ISOMessage";
     public final static String TAG_DATA = "data";
     public final static String TAG_ID = "id";
-    public static final String INBOUND_SEQUENTIAL = "sequential";
     public static final String PORT = "port";
     public static final String PACKAGER = "jposdef.xml";
     public static final String CORE_THREADS = "1";
@@ -34,6 +34,9 @@ public class ISO8583Constant {
     public static final String INBOUND_MAX_THREADS = "maxThreads";
     public static final String INBOUND_THREAD_ALIVE = "keepAlive";
     public static final String INBOUND_THREAD_QLEN = "queueLength";
+    public static final String INBOUND_SEQUENTIAL = "sequential";
+    public static final String INBOUND_HEADER_LENGTH = "headerLength";
+    public static final String INBOUND_ACT_AS_PROXY = "isProxy";
     public final static String ISO8583_INBOUND_MSG_ID = "ISO8583_INBOUND_MSG_ID";
     public final static String PROPERTIES_FILE = "config.properties";
     public static final String RESPONSE_FIELD = "responseField";

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583MessageConnection.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583MessageConnection.java
@@ -54,8 +54,8 @@ public class ISO8583MessageConnection extends Thread {
         String threadSafeTime = properties.getProperty(ISO8583Constant.INBOUND_THREAD_ALIVE);
         String queueLength = properties.getProperty(ISO8583Constant.INBOUND_THREAD_QLEN);
         try {
-            if ((!StringUtils.isEmpty(coreThreads)) && (!StringUtils.isEmpty(maxThreads)) &&
-                    (!StringUtils.isEmpty(threadSafeTime)) && (!StringUtils.isEmpty(queueLength))) {
+            if ((StringUtils.isNotEmpty(coreThreads)) && (StringUtils.isNotEmpty(maxThreads)) &&
+                    (StringUtils.isNotEmpty(threadSafeTime)) && (StringUtils.isNotEmpty(queueLength))) {
                 BlockingQueue<Runnable> workQueue = new LinkedBlockingQueue<Runnable>(Integer.parseInt(queueLength));
                 threadPool = new ThreadPoolExecutor(Integer.parseInt(coreThreads), Integer.parseInt(maxThreads)
                         , Integer.parseInt(threadSafeTime), TimeUnit.SECONDS, workQueue);

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583MessageInject.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583MessageInject.java
@@ -20,6 +20,7 @@ import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
 import org.apache.axiom.om.util.UUIDGenerator;
 import org.apache.axis2.context.MessageContext;
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.core.SynapseEnvironment;
@@ -32,6 +33,7 @@ import org.wso2.carbon.base.MultitenantConstants;
 import org.wso2.carbon.context.PrivilegedCarbonContext;
 
 import java.net.Socket;
+import java.util.Base64;
 import java.util.Properties;
 
 /**
@@ -45,11 +47,12 @@ public class ISO8583MessageInject {
     private final SynapseEnvironment synapseEnvironment;
     private InboundProcessorParams params;
     private Socket connection;
+    private Properties properties;
 
     public ISO8583MessageInject(InboundProcessorParams params, Socket connection) {
         this.params = params;
         this.connection = connection;
-        Properties properties = params.getProperties();
+        this.properties = params.getProperties();
         this.injectingSeq = params.getInjectingSeq();
         this.onErrorSeq = params.getOnErrorSeq();
         this.sequential = Boolean.parseBoolean(properties.getProperty(ISO8583Constant.INBOUND_SEQUENTIAL));
@@ -119,9 +122,14 @@ public class ISO8583MessageInject {
     private OMElement messageBuilder(ISOMsg isomsg) {
         OMFactory OMfactory = OMAbstractFactory.getOMFactory();
         OMElement parentElement = OMfactory.createOMElement(ISO8583Constant.TAG_MSG, null);
-        OMElement header = OMfactory.createOMElement(ISO8583Constant.HEADER, null);
-        header.setText(new String(isomsg.getHeader()));
-        parentElement.addChild(header);
+        String headerLength = properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH);
+        if (!StringUtils.isEmpty(headerLength)) {
+            if (Integer.parseInt(headerLength) > 0) {
+                OMElement header = OMfactory.createOMElement(ISO8583Constant.HEADER, null);
+                header.setText(Base64.getEncoder().encodeToString(isomsg.getHeader()));
+                parentElement.addChild(header);
+            }
+        }
         OMElement result = OMfactory.createOMElement(ISO8583Constant.TAG_DATA, null);
         for (int i = 0; i <= isomsg.getMaxField(); i++) {
             if (isomsg.hasField(i)) {

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583MessageInject.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583MessageInject.java
@@ -78,8 +78,7 @@ public class ISO8583MessageInject {
         try {
             OMElement parentElement = messageBuilder(object);
             msgCtx.getEnvelope().getBody().addChild(parentElement);
-            ISO8583ReplySender replySender = new ISO8583ReplySender(connection);
-            replySender.sendBack(msgCtx);
+            ISO8583ReplySender replySender = new ISO8583ReplySender(connection, params);
             if (seq != null) {
                 seq.setErrorHandler(onErrorSeq);
                 if (log.isDebugEnabled()) {
@@ -89,6 +88,7 @@ public class ISO8583MessageInject {
             } else {
                 log.error("Sequence: " + injectingSeq + " not found");
             }
+            replySender.sendBack(msgCtx);
         } catch (Exception e) {
             log.error(e.getMessage(), e);
         }
@@ -119,6 +119,9 @@ public class ISO8583MessageInject {
     private OMElement messageBuilder(ISOMsg isomsg) {
         OMFactory OMfactory = OMAbstractFactory.getOMFactory();
         OMElement parentElement = OMfactory.createOMElement(ISO8583Constant.TAG_MSG, null);
+        OMElement header = OMfactory.createOMElement(ISO8583Constant.HEADER, null);
+        header.setText(new String(isomsg.getHeader()));
+        parentElement.addChild(header);
         OMElement result = OMfactory.createOMElement(ISO8583Constant.TAG_DATA, null);
         for (int i = 0; i <= isomsg.getMaxField(); i++) {
             if (isomsg.hasField(i)) {

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583MessageInject.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583MessageInject.java
@@ -123,7 +123,7 @@ public class ISO8583MessageInject {
         OMFactory OMfactory = OMAbstractFactory.getOMFactory();
         OMElement parentElement = OMfactory.createOMElement(ISO8583Constant.TAG_MSG, null);
         String headerLength = properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH);
-        if (!StringUtils.isEmpty(headerLength)) {
+        if (StringUtils.isNotEmpty(headerLength)) {
             if (Integer.parseInt(headerLength) > 0) {
                 OMElement header = OMfactory.createOMElement(ISO8583Constant.HEADER, null);
                 header.setText(Base64.getEncoder().encodeToString(isomsg.getHeader()));

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583PackagerFactory.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583PackagerFactory.java
@@ -50,16 +50,16 @@ public class ISO8583PackagerFactory {
         try {
             Properties properties = params.getProperties();
             int headerLength = 0;
-            String hLength = properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH);
-            if (!StringUtils.isEmpty(hLength))
-                headerLength = Integer.parseInt(hLength);
+            if (!StringUtils.isEmpty(properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH))) {
+                headerLength = Integer.parseInt(properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH));
+            }
             ClassLoader loader = Thread.currentThread().getContextClassLoader();
             packager = new GenericPackager(loader.getResourceAsStream(ISO8583Constant.PACKAGER));
             packager.setHeaderLength(headerLength);
         } catch (NumberFormatException e) {
-            handleException("One of the properties are of an invalid type", e);
+            handleException("One of the properties is invalid type", e);
         } catch (ISOException e) {
-            handleException("Error while get the ISOPackager", e);
+            handleException("Error while getting the ISOPackager", e);
         }
         return packager;
     }

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583PackagerFactory.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583PackagerFactory.java
@@ -19,9 +19,13 @@ package org.wso2.carbon.inbound.iso8583.listening;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.inbound.InboundProcessorParams;
+import org.jpos.iso.ISOBasePackager;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOPackager;
 import org.jpos.iso.packager.GenericPackager;
+
+import java.util.Properties;
 
 /**
  * class for get ISOPackager.
@@ -34,6 +38,23 @@ public class ISO8583PackagerFactory {
         try {
             ClassLoader loader = Thread.currentThread().getContextClassLoader();
             packager = new GenericPackager(loader.getResourceAsStream(ISO8583Constant.PACKAGER));
+        } catch (ISOException e) {
+            handleException("Error while get the ISOPackager", e);
+        }
+        return packager;
+    }
+
+    public static ISOBasePackager getPackagerWithParams(InboundProcessorParams params) {
+        ISOBasePackager packager = null;
+        try {
+            Properties properties = params.getProperties();
+            int headerLength = Integer.parseInt(properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH));
+            headerLength = headerLength > -1 ? headerLength : 0;
+            ClassLoader loader = Thread.currentThread().getContextClassLoader();
+            packager = new GenericPackager(loader.getResourceAsStream(ISO8583Constant.PACKAGER));
+            packager.setHeaderLength(headerLength);
+        } catch (NumberFormatException e) {
+            handleException("One of the properties are of an invalid type", e);
         } catch (ISOException e) {
             handleException("Error while get the ISOPackager", e);
         }

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583PackagerFactory.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583PackagerFactory.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.inbound.iso8583.listening;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.SynapseException;
@@ -48,8 +49,10 @@ public class ISO8583PackagerFactory {
         ISOBasePackager packager = null;
         try {
             Properties properties = params.getProperties();
-            int headerLength = Integer.parseInt(properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH));
-            headerLength = headerLength > -1 ? headerLength : 0;
+            int headerLength = 0;
+            String hLength = properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH);
+            if (!StringUtils.isEmpty(hLength))
+                headerLength = Integer.parseInt(hLength);
             ClassLoader loader = Thread.currentThread().getContextClassLoader();
             packager = new GenericPackager(loader.getResourceAsStream(ISO8583Constant.PACKAGER));
             packager.setHeaderLength(headerLength);

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583PackagerFactory.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583PackagerFactory.java
@@ -45,12 +45,17 @@ public class ISO8583PackagerFactory {
         return packager;
     }
 
+    /**
+     * Get the ISOPackager
+     * @param params the inbound parameters
+     * @return
+     */
     public static ISOBasePackager getPackagerWithParams(InboundProcessorParams params) {
         ISOBasePackager packager = null;
         try {
             Properties properties = params.getProperties();
             int headerLength = 0;
-            if (!StringUtils.isEmpty(properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH))) {
+            if (StringUtils.isNotEmpty(properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH))) {
                 headerLength = Integer.parseInt(properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH));
             }
             ClassLoader loader = Thread.currentThread().getContextClassLoader();

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583ReplySender.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583ReplySender.java
@@ -33,6 +33,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.Socket;
+import java.util.Base64;
 import java.util.Iterator;
 import java.util.Properties;
 
@@ -85,9 +86,10 @@ public class ISO8583ReplySender implements InboundResponseSender {
             }
             ISOMsg isoMsg = new ISOMsg();
             isoMsg.setPackager(packager);
-            String header = getElements.getFirstChildWithName(
-                    new QName(ISO8583Constant.HEADER)).getText();
-            isoMsg.setHeader(header.getBytes());
+            if (packager.getHeaderLength() > 0) {
+                String header = getElements.getFirstChildWithName(new QName(ISO8583Constant.HEADER)).getText();
+                isoMsg.setHeader(Base64.getDecoder().decode(header));
+            }
             Iterator fields = getElements.getFirstChildWithName(
                     new QName(ISO8583Constant.TAG_DATA)).getChildrenWithLocalName(ISO8583Constant.TAG_FIELD);
             while (fields.hasNext()) {

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583ReplySender.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583ReplySender.java
@@ -80,7 +80,6 @@ public class ISO8583ReplySender implements InboundResponseSender {
             } else {
                 getElements = soapEnvelope.getBody().getFirstElement();
             }
-
             if (getElements == null) {
                 handleException("Failed to get response message", null);
             }
@@ -111,13 +110,13 @@ public class ISO8583ReplySender implements InboundResponseSender {
                 /* Set the response fields */
                 if (isoMsg.getMTI().equals(properties.getProperty((String) ISO8583Constant.REQUEST_MTI))) {
                     isoMsg.setMTI((properties.getProperty((String) ISO8583Constant.RESPONSE_MTI)));
-                /* Set the code for successful response */
+                    /* Set the code for successful response */
                     isoMsg.set(properties.getProperty(ISO8583Constant.RESPONSE_FIELD),
                             properties.getProperty(ISO8583Constant.SUCCESSFUL_RESPONSE_CODE));
                     byte[] msg = isoMsg.pack();
                     responseMessage = new String(msg).toUpperCase();
                 } else {
-                /* Set the code for invalid transaction response */
+                    /* Set the code for invalid transaction response */
                     isoMsg.set(properties.getProperty(ISO8583Constant.RESPONSE_FIELD),
                             properties.getProperty(ISO8583Constant.FAILURE_RESPONSE_CODE));
                     byte[] msg = isoMsg.pack();
@@ -186,7 +185,6 @@ public class ISO8583ReplySender implements InboundResponseSender {
     private boolean isProxy() {
         Properties properties = this.params.getProperties();
         boolean isProxy = Boolean.parseBoolean(properties.getProperty(ISO8583Constant.INBOUND_ACT_AS_PROXY));
-
         return  isProxy;
     }
 }

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583ReplySender.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583ReplySender.java
@@ -21,7 +21,9 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.SynapseException;
+import org.apache.synapse.inbound.InboundProcessorParams;
 import org.apache.synapse.inbound.InboundResponseSender;
+import org.jpos.iso.ISOBasePackager;
 import org.jpos.iso.ISOException;
 import org.jpos.iso.ISOMsg;
 import org.jpos.iso.ISOPackager;
@@ -42,14 +44,16 @@ public class ISO8583ReplySender implements InboundResponseSender {
     private static final Log log = LogFactory.getLog(ISO8583ReplySender.class.getName());
 
     private Socket connection;
+    private InboundProcessorParams params;
 
     /**
      * keep the socket connection to send the response back to client.
      *
      * @param connection created socket connection.
      */
-    public ISO8583ReplySender(Socket connection) {
+    public ISO8583ReplySender(Socket connection, InboundProcessorParams params) {
         this.connection = connection;
+        this.params = params;
     }
 
     /**
@@ -61,13 +65,29 @@ public class ISO8583ReplySender implements InboundResponseSender {
     public void sendBack(MessageContext messageContext) {
         String responseMessage = null;
         try {
-            ISOPackager packager = ISO8583PackagerFactory.getPackager();
+            ISOBasePackager packager = ISO8583PackagerFactory.getPackagerWithParams(params);
             Properties properties = getPropertiesFile();
             //Retrieve the SOAP envelope from the MessageContext
             SOAPEnvelope soapEnvelope = messageContext.getEnvelope();
-            OMElement getElements = soapEnvelope.getBody().getFirstElement();
+            OMElement getElements = null;
+            if (isProxy()) {
+                Iterator<OMElement> iterator = soapEnvelope.getBody().getChildrenWithName(
+                        new QName(ISO8583Constant.TAG_MSG));
+                while (iterator.hasNext()) {
+                    getElements = iterator.next();
+                }
+            } else {
+                getElements = soapEnvelope.getBody().getFirstElement();
+            }
+
+            if (getElements == null) {
+                handleException("Failed to get response message", null);
+            }
             ISOMsg isoMsg = new ISOMsg();
             isoMsg.setPackager(packager);
+            String header = getElements.getFirstChildWithName(
+                    new QName(ISO8583Constant.HEADER)).getText();
+            isoMsg.setHeader(header.getBytes());
             Iterator fields = getElements.getFirstChildWithName(
                     new QName(ISO8583Constant.TAG_DATA)).getChildrenWithLocalName(ISO8583Constant.TAG_FIELD);
             while (fields.hasNext()) {
@@ -81,20 +101,26 @@ public class ISO8583ReplySender implements InboundResponseSender {
                     log.warn("The fieldID does not contain a parsable integer" + e.getMessage(), e);
                 }
             }
-            /* Set the response fields */
-            if (isoMsg.getMTI().equals(properties.getProperty((String) ISO8583Constant.REQUEST_MTI))) {
-                isoMsg.setMTI((properties.getProperty((String) ISO8583Constant.RESPONSE_MTI)));
-                /* Set the code for successful response */
-                isoMsg.set(properties.getProperty(ISO8583Constant.RESPONSE_FIELD),
-                        properties.getProperty(ISO8583Constant.SUCCESSFUL_RESPONSE_CODE));
+
+            if (isProxy()) {
                 byte[] msg = isoMsg.pack();
                 responseMessage = new String(msg).toUpperCase();
             } else {
+                /* Set the response fields */
+                if (isoMsg.getMTI().equals(properties.getProperty((String) ISO8583Constant.REQUEST_MTI))) {
+                    isoMsg.setMTI((properties.getProperty((String) ISO8583Constant.RESPONSE_MTI)));
+                /* Set the code for successful response */
+                    isoMsg.set(properties.getProperty(ISO8583Constant.RESPONSE_FIELD),
+                            properties.getProperty(ISO8583Constant.SUCCESSFUL_RESPONSE_CODE));
+                    byte[] msg = isoMsg.pack();
+                    responseMessage = new String(msg).toUpperCase();
+                } else {
                 /* Set the code for invalid transaction response */
-                isoMsg.set(properties.getProperty(ISO8583Constant.RESPONSE_FIELD),
-                        properties.getProperty(ISO8583Constant.FAILURE_RESPONSE_CODE));
-                byte[] msg = isoMsg.pack();
-                responseMessage = new String(msg).toUpperCase();
+                    isoMsg.set(properties.getProperty(ISO8583Constant.RESPONSE_FIELD),
+                            properties.getProperty(ISO8583Constant.FAILURE_RESPONSE_CODE));
+                    byte[] msg = isoMsg.pack();
+                    responseMessage = new String(msg).toUpperCase();
+                }
             }
         } catch (ISOException e) {
             handleException("Couldn't packed ISO8583 Messages", e);
@@ -148,5 +174,17 @@ public class ISO8583ReplySender implements InboundResponseSender {
     private void handleException(String msg, Exception e) {
         log.error(msg, e);
         throw new SynapseException(msg);
+    }
+
+    /**
+     * Is this inbound endpoint act as a proxy to another service
+     *
+     * @return act as a proxy or not
+     */
+    private boolean isProxy() {
+        Properties properties = this.params.getProperties();
+        boolean isProxy = Boolean.parseBoolean(properties.getProperty(ISO8583Constant.INBOUND_ACT_AS_PROXY));
+
+        return  isProxy;
     }
 }

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583ReplySender.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583ReplySender.java
@@ -71,6 +71,11 @@ public class ISO8583ReplySender implements InboundResponseSender {
             //Retrieve the SOAP envelope from the MessageContext
             SOAPEnvelope soapEnvelope = messageContext.getEnvelope();
             OMElement getElements = null;
+            /* isProxy defines whether this inbound is acting as a proxy for
+                another backend service or processing the message itself.
+                if the inbound endpoint act as a proxy to another service
+                pack the ISO message without change any field
+             */
             if (isProxy()) {
                 Iterator<OMElement> iterator = soapEnvelope.getBody().getChildrenWithName(
                         new QName(ISO8583Constant.TAG_MSG));


### PR DESCRIPTION
## Purpose
The current Implementation doesn't support the message with different header length(2 or 4).

## Goals
Implement the inbound to support iso8583 message with header

## Approach


## User stories


## Release note


## Documentation


## Training


## Certification


## Marketing


## Automation tests


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples


## Related PRs


## Migrations (if applicable)

## Test environment
JDK versions-1.8
Operating systems-Ubuntu 16.04
Product- EI-6.1.1
