### PR TITLE
Support headers with different header length

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@ Copyright (c) 2016, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.apache.synapse.inbound</groupId>
     <artifactId>org.wso2.carbon.inbound.iso8583</artifactId>
-    <version>1.0.2-SNAPSHOT</version>
+    <version>1.0.1</version>
     <name>ISO8583 listening</name>
     <url>http://wso2.org</url>
     <packaging>bundle</packaging>

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583MessageInject.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583MessageInject.java
@@ -122,13 +122,10 @@ public class ISO8583MessageInject {
     private OMElement messageBuilder(ISOMsg isomsg) {
         OMFactory OMfactory = OMAbstractFactory.getOMFactory();
         OMElement parentElement = OMfactory.createOMElement(ISO8583Constant.TAG_MSG, null);
-        String headerLength = properties.getProperty(ISO8583Constant.INBOUND_HEADER_LENGTH);
-        if (StringUtils.isNotEmpty(headerLength)) {
-            if (Integer.parseInt(headerLength) > 0) {
-                OMElement header = OMfactory.createOMElement(ISO8583Constant.HEADER, null);
-                header.setText(Base64.getEncoder().encodeToString(isomsg.getHeader()));
-                parentElement.addChild(header);
-            }
+        if (isomsg.getHeader() != null) {
+            OMElement header = OMfactory.createOMElement(ISO8583Constant.HEADER, null);
+            header.setText(Base64.getEncoder().encodeToString(isomsg.getHeader()));
+            parentElement.addChild(header);
         }
         OMElement result = OMfactory.createOMElement(ISO8583Constant.TAG_DATA, null);
         for (int i = 0; i <= isomsg.getMaxField(); i++) {

--- a/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583MessageInject.java
+++ b/src/main/java/org/wso2/carbon/inbound/iso8583/listening/ISO8583MessageInject.java
@@ -20,7 +20,6 @@ import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMFactory;
 import org.apache.axiom.om.util.UUIDGenerator;
 import org.apache.axis2.context.MessageContext;
-import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.core.SynapseEnvironment;


### PR DESCRIPTION
## Purpose
support the message with different header length

## Goals
Implement the inbound to support iso8583 message with header

## Approach


## User stories

## Release note


## Documentation


## Training


## Certification


## Marketing


## Automation tests


## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples


## Related PRs


## Migrations (if applicable)


## Test environment

 
## Learning
JDK versions-1.8
Operating systems-Ubuntu 16.04
Product- EI-6.1.1